### PR TITLE
Add "dynamic" locks to lockjaw component

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,8 +95,17 @@ acquire the lock. It can also be configured to never acquire it:
   (.stop never-lock))
 ```
 
+# Testing
+
+Just run:
+
+`lein test`
+
+> Ensure no other database connections are currently holding advisory locks when running tests.
+
 # Change log
 
+- 2021-11-09 - updates dependencies, includes `next.jdbc`, allows passing lock-name when asking for lock.
 - *unreleased* - 0.2.0-SNAPSHOT, switches to `next.jdbc`
 - 2019-10-24 - 0.1.2, Initial public offering
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject nomnom/lockjaw "0.2.1-SNAPSHOT"
+(defproject nomnom/lockjaw "0.3.0-SNAPSHOT"
   :description "Postgres Advisory Locks as a Component"
   :url "https://github.com/nomnom-insights/nomnom.lockjaw"
   :license {:name "MIT License"

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject nomnom/lockjaw "0.2.0-SNAPSHOT"
+(defproject nomnom/lockjaw "0.2.1-SNAPSHOT"
   :description "Postgres Advisory Locks as a Component"
   :url "https://github.com/nomnom-insights/nomnom.lockjaw"
   :license {:name "MIT License"
@@ -9,14 +9,14 @@
                                    :username :env/clojars_username
                                    :password :env/clojars_password}}
 
-  :dependencies [[org.clojure/clojure "1.10.1"]
-                 [seancorfield/next.jdbc "1.0.13"]
-                 [com.stuartsierra/component "0.4.0"]]
+  :dependencies [[org.clojure/clojure "1.10.3"]
+                 [seancorfield/next.jdbc "1.2.659"]
+                 [com.stuartsierra/component "1.0.0"]]
   :plugins [[lein-cloverage "1.0.13" :exclusions [org.clojure/clojure]]]
   :profiles {:dev
              {:resource-paths ["dev-resources"]
-              :dependencies [[ch.qos.logback/logback-classic "1.2.3"]
+              :dependencies [[ch.qos.logback/logback-classic "1.2.6"]
                              ;; pulls in all the PG bits and a connection pool
                              ;; component
-                             [nomnom/utility-belt.sql "1.0.0-SNAPSHOT"]
-                             [org.clojure/tools.logging "0.5.0"]]}})
+                             [nomnom/utility-belt.sql "1.0.1"]
+                             [org.clojure/tools.logging "1.1.0"]]}})

--- a/src/lockjaw/core.clj
+++ b/src/lockjaw/core.clj
@@ -15,11 +15,25 @@
     (log/warnf "name=%s status=stopping lock-id=%s cleaning all locks!" name lock-id)
     (operation/release-all-locks! db-conn)
     (assoc this :lock-id nil))
+
   lockjaw/Lockjaw
   (acquire! [this]
     (operation/acquire-lock db-conn lock-id))
+
+  (acquire-by-name! [this lock-name]
+    (let [lock-id (util/name-to-id lock-name)]
+      (operation/acquire-lock db-conn lock-id)))
+
   (release! [this]
-    (operation/release-lock db-conn lock-id)))
+    (operation/release-lock db-conn lock-id))
+
+  (release-by-name! [this lock-name]
+    (let [lock-id (util/name-to-id lock-name)]
+      (operation/release-lock db-conn lock-id)))
+
+  (release-all! [this]
+    (operation/release-all-locks! db-conn)))
+
 
 (defn create [{:keys [name] :as args}]
   {:pre [(and (string? name) (not (.isEmpty ^String name)))]}

--- a/src/lockjaw/operation.clj
+++ b/src/lockjaw/operation.clj
@@ -1,4 +1,5 @@
 (ns lockjaw.operation
+  (:refer-clojure :exclude [key])
   (:require [next.jdbc :as jdbc]))
 
 (def acquire-lock-query "SELECT pg_try_advisory_lock(?)")

--- a/src/lockjaw/protocol.clj
+++ b/src/lockjaw/protocol.clj
@@ -2,9 +2,15 @@
 
 (defprotocol Lockjaw
   (acquire! [this]
-    "Tries to get a lock for given ID")
+    "Tries to get a lock for given component ID")
+  (acquire-by-name! [this lock-name]
+    "Converts passed name to ID and tries to aquire a lock for it")
   (release! [this]
-    "Rleases the lock"))
+    "Rleases the component lock")
+  (release-by-name! [this lock-name]
+    "Converts passed name to ID and releases it")
+  (release-all! [this]
+    "Releases all acquired locks"))
 
 (defmacro with-lock
   "Run the code if a lock is obtained"

--- a/src/lockjaw/protocol.clj
+++ b/src/lockjaw/protocol.clj
@@ -30,3 +30,23 @@
        :lockjaw.operation/no-lock)
      (finally
        (release! ~a-lock))))
+
+(defmacro with-named-lock
+  "Run the code if a lock with the passed name is obtained"
+  [a-lock lock-name & body]
+  `(if (acquire-by-name! ~a-lock ~lock-name)
+     (do
+       ~@body)
+     :lockjaw.operation/no-lock))
+
+(defmacro with-named-lock!
+  "Like *with-lock* but release it after use"
+  [a-lock lock-name & body]
+  `(try
+     (if (acquire-by-name! ~a-lock ~lock-name)
+       (do
+         ~@body)
+       :lockjaw.operation/no-lock)
+     (finally
+       (release-by-name! ~a-lock ~lock-name))))
+

--- a/test/lockjaw/core_test.clj
+++ b/test/lockjaw/core_test.clj
@@ -30,7 +30,13 @@
   (testing "lock-1 gets a lock, lock-2 doesnt"
     (is (lock/acquire! (:lock-1 @sys)))
     (is (false? (lock/acquire! (:lock-2 @sys))))
-    (is (lock/release! (:lock-1 @sys)))))
+    (is (lock/release! (:lock-1 @sys))))
+
+  (testing "gets and releases locks by name"
+    (is (lock/acquire-by-name! (:lock-1 @sys) "foo"))
+    (is (false? (lock/acquire-by-name! (:lock-2 @sys) "foo")))
+    (is (lock/release-by-name! (:lock-1 @sys) "foo"))
+    (is (nil? (lock/release-by-name! (:lock-2 @sys "foo"))))))
 
 (deftest a-handy-macro
   (testing "nice macro ensures lock clean up"

--- a/test/lockjaw/core_test.clj
+++ b/test/lockjaw/core_test.clj
@@ -36,9 +36,9 @@
     (is (lock/acquire-by-name! (:lock-1 @sys) "foo"))
     (is (false? (lock/acquire-by-name! (:lock-2 @sys) "foo")))
     (is (lock/release-by-name! (:lock-1 @sys) "foo"))
-    (is (nil? (lock/release-by-name! (:lock-2 @sys "foo"))))))
+    (is (false? (lock/release-by-name! (:lock-2 @sys) "foo")))))
 
-(deftest a-handy-macro
+(deftest handy-macros
   (testing "nice macro ensures lock clean up"
     (let [fut (future
                 (lock/with-lock (:lock-1 @sys)
@@ -47,6 +47,18 @@
       (Thread/sleep 10)
       (is (= :lockjaw.operation/no-lock
              (lock/with-lock! (:lock-2 @sys)
+               ::invalid)))
+      (is (= ::done
+             @fut))))
+  (testing "nice macro with name ensures lock clean up too"
+    (let [lock-name "a-nice-lock"
+          fut (future
+                (lock/with-named-lock (:lock-1 @sys) lock-name
+                  (Thread/sleep 50)
+                  ::done))]
+      (Thread/sleep 10)
+      (is (= :lockjaw.operation/no-lock
+             (lock/with-named-lock! (:lock-2 @sys) lock-name
                ::invalid)))
       (is (= ::done
              @fut)))))


### PR DESCRIPTION
After creating the component, we could simply acquire a lock with the component name (application level locking)

This PR introduces an API that takes a name, generates an id for that name, and acquires/releases that lock.

It also updates all libraries for the latest versions. 
