### PR TITLE
Check if lock is acquired

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ Just run:
 
 # Change log
 
+- 2022-02-08 - 0.3.1 - adds "acquired?" functions to check if a lock was already acquired. Updates dependencies (next.jdbc, logback-classic, tools.logging)
 - 2021-12-08 - 0.3.0 - "dynamic" locks, updated dependencies
 - 2021-11-09 - 0.2.1-SNAPSHOT, updates dependencies, includes `next.jdbc`, allows passing lock-name when asking for lock.
 - *unreleased* - 0.2.0-SNAPSHOT, switches to `next.jdbc`

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject nomnom/lockjaw "0.3.1-SNAPSHOT"
+(defproject nomnom/lockjaw "0.3.1"
   :description "Postgres Advisory Locks as a Component"
   :url "https://github.com/nomnom-insights/nomnom.lockjaw"
   :license {:name "MIT License"

--- a/project.clj
+++ b/project.clj
@@ -10,12 +10,12 @@
                                    :password :env/clojars_password}}
 
   :dependencies [[org.clojure/clojure "1.10.3"]
-                 [com.github.seancorfield/next.jdbc "1.2.753"]
+                 [com.github.seancorfield/next.jdbc "1.2.761"]
                  [com.stuartsierra/component "1.0.0"]]
   :profiles {:dev
              {:resource-paths ["dev-resources"]
-              :dependencies [[ch.qos.logback/logback-classic "1.2.7"]
+              :dependencies [[ch.qos.logback/logback-classic "1.2.10"]
                              ;; pulls in all the PG bits and a connection pool
                              ;; component
                              [nomnom/utility-belt.sql "1.1.0"]
-                             [org.clojure/tools.logging "1.1.0"]]}})
+                             [org.clojure/tools.logging "1.2.4"]]}})

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject nomnom/lockjaw "0.3.0"
+(defproject nomnom/lockjaw "0.3.1-SNAPSHOT"
   :description "Postgres Advisory Locks as a Component"
   :url "https://github.com/nomnom-insights/nomnom.lockjaw"
   :license {:name "MIT License"

--- a/src/lockjaw/core.clj
+++ b/src/lockjaw/core.clj
@@ -26,7 +26,9 @@
   (acquire-by-name! [_ lock-name]
     (let [lock-id (util/name-to-id lock-name)]
       (operation/acquire-lock db-conn lock-id)))
-  (acquired? [_ lock-name]
+  (acquired? [_]
+    (operation/lock-acquired? db-conn lock-id))
+  (acquired-by-name? [_ lock-name]
     (let [lock-id (util/name-to-id lock-name)]
       (operation/lock-acquired? db-conn lock-id)))
   (release! [_]

--- a/src/lockjaw/core.clj
+++ b/src/lockjaw/core.clj
@@ -26,6 +26,9 @@
   (acquire-by-name! [_ lock-name]
     (let [lock-id (util/name-to-id lock-name)]
       (operation/acquire-lock db-conn lock-id)))
+  (acquired? [_ lock-name]
+    (let [lock-id (util/name-to-id lock-name)]
+      (operation/lock-acquired? db-conn lock-id)))
   (release! [_]
     (operation/release-lock db-conn lock-id))
   (release-by-name! [_ lock-name]

--- a/src/lockjaw/operation.clj
+++ b/src/lockjaw/operation.clj
@@ -56,6 +56,9 @@
       (swap! registry (partial dec-key lock-id)))
     res))
 
+(defn lock-acquired?
+  [db-conn lock-id]
+  (boolean (jdbc/execute-one! db-conn [find-lock-for-id-query lock-id])))
 
 (defn release-all-locks!
   "Releases all locks hold by this connection, regardless of how many were acquired"

--- a/src/lockjaw/operation.clj
+++ b/src/lockjaw/operation.clj
@@ -56,9 +56,11 @@
       (swap! registry (partial dec-key lock-id)))
     res))
 
+
 (defn lock-acquired?
   [db-conn lock-id]
   (boolean (jdbc/execute-one! db-conn [find-lock-for-id-query lock-id])))
+
 
 (defn release-all-locks!
   "Releases all locks hold by this connection, regardless of how many were acquired"

--- a/src/lockjaw/protocol.clj
+++ b/src/lockjaw/protocol.clj
@@ -6,6 +6,8 @@
     "Tries to get a lock for given component ID")
   (acquire-by-name! [this lock-name]
     "Converts passed name to ID and tries to aquire a lock for it")
+  (acquired? [this lock-name]
+    "Converts passed name to ID and cheks if lock was already acquired")
   (release! [this]
     "Rleases the component lock")
   (release-by-name! [this lock-name]

--- a/src/lockjaw/protocol.clj
+++ b/src/lockjaw/protocol.clj
@@ -6,8 +6,10 @@
     "Tries to get a lock for given component ID")
   (acquire-by-name! [this lock-name]
     "Converts passed name to ID and tries to aquire a lock for it")
-  (acquired? [this lock-name]
-    "Converts passed name to ID and cheks if lock was already acquired")
+  (acquired? [this]
+    "Checks if lock was already acquired")
+  (acquired-by-name? [this lock-name]
+    "Converts passed name to ID and checks if lock was already acquired")
   (release! [this]
     "Rleases the component lock")
   (release-by-name! [this lock-name]

--- a/test/lockjaw/core_test.clj
+++ b/test/lockjaw/core_test.clj
@@ -40,10 +40,13 @@
     (is (false? (lock/acquire-by-name! (:lock-2 @sys) "foo")))
     (is (lock/release-by-name! (:lock-1 @sys) "foo"))
     (is (false? (lock/release-by-name! (:lock-2 @sys) "foo"))))
+  (testing "checks if lock is acquired"
+    (is (lock/acquire! (:lock-1 @sys)))
+    (is (lock/acquired? (:lock-1 @sys))))
   (testing "checks if lock acquired by name"
     (is (lock/acquire-by-name! (:lock-1 @sys) "alock"))
-    (is (lock/acquired? (:lock-1 @sys) "alock"))
-    (is (false? (lock/acquired? (:lock-1 @sys) "no lock")))))
+    (is (lock/acquired-by-name? (:lock-1 @sys) "alock"))
+    (is (false? (lock/acquired-by-name? (:lock-1 @sys) "no lock")))))
 
 
 (deftest handy-macros

--- a/test/lockjaw/core_test.clj
+++ b/test/lockjaw/core_test.clj
@@ -39,7 +39,11 @@
     (is (lock/acquire-by-name! (:lock-1 @sys) "foo"))
     (is (false? (lock/acquire-by-name! (:lock-2 @sys) "foo")))
     (is (lock/release-by-name! (:lock-1 @sys) "foo"))
-    (is (false? (lock/release-by-name! (:lock-2 @sys) "foo")))))
+    (is (false? (lock/release-by-name! (:lock-2 @sys) "foo"))))
+  (testing "checks if lock acquired by name"
+    (is (lock/acquire-by-name! (:lock-1 @sys) "alock"))
+    (is (lock/acquired? (:lock-1 @sys) "alock"))
+    (is (false? (lock/acquired? (:lock-1 @sys) "no lock")))))
 
 
 (deftest handy-macros


### PR DESCRIPTION
Since locks are re-entrant per connection, it is handy to have a way to check if a certain connection has already acquired a lock.

This PR adds this feature using the already existent "find-lock-for-id" query and exposes this feature in the lock component.